### PR TITLE
Multi-Series DPS helpers

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,6 +26,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[dev]
 
+    - name: Show installed packages
+      run: pip list
+
     - name: Set PYTHONPATH
       run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -288,7 +288,7 @@ class DPSHelper:
         else:
             self._add_multi_series_subscription([join_payload], handle_data_method, parse_datetimes)
 
-    def subscribe_to_multiple_series_updates_for_plant(
+    def subscribe_to_multiple_plant_series_updates(
         self,
         handle_data_method: Callable[[str], None],
         plant_series_requests: list[dict],

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -237,7 +237,7 @@ class DPSHelper:
             return data_push_holder
 
     def terminate_hub_connection(self):
-        #self._suppress_restart = True
+        self._suppress_restart = True
         self.hub_connection.stop()
 
     def subscribe_to_epex_trade_updates(self, handle_data_method: Callable[[str], None]) -> None:

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -316,7 +316,6 @@ class DPSHelper:
                 The function should accept one argument, which will be the data received from the series updates.
 
             series_requests `list[dict]`: A list of dictionaries, with each element detailing a series request. Each element needs a countryId, seriesId, and if relevant, optionIds.
-                                          If subscribing to a series that requires options and it is ommited, you will subscribe to pushes for all options
 
             parse_datetimes `bool` (optional): Parse returned DataFrame index to DateTime (UTC). Defaults to False.
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -33,8 +33,9 @@ class DPSHelper:
         )
 
         self.hub_connection.on_open(self._on_open)
-        self.hub_connection.on_close((self._on_close)) #on_close(lambda: print("Connection closed")) #(self._on_close)
+        self.hub_connection.on_close((self._on_close))
         self.hub_connection.on_error(lambda e: print("SignalR error:", e))
+        self.hub_connection.on_reconnect(lambda: print("reconnected!"))
 
         success = self.hub_connection.start()
         pytime.sleep(1)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -1,6 +1,5 @@
 import time as pytime
 import pandas as pd
-import ssl
 from datetime import datetime as dt
 from functools import partial
 from typing import Callable

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -165,8 +165,7 @@ class DPSHelper:
 
     def _process_multi_series_push(self, data_push, handle_data_method, parse_datetimes):
         updated_data = self._handle_new_mutli_series_data(data_push, parse_datetimes)
-        if not updated_data.empty:
-            handle_data_method(updated_data)
+        handle_data_method(updated_data)
 
     def _handle_new_series_data(
         self, all_data: pd.DataFrame, data_push_holder: list, parse_datetimes: bool
@@ -179,8 +178,6 @@ class DPSHelper:
             pushes = data_push["data"]
             for push in pushes:
                 push_current = push["current"]
-                if not push_current.get("datePeriod"):
-                    continue
                 push_date_time = f'{push_current["datePeriod"]["datePeriodCombinedGmt"]}'
                 if push_date_time[-1:] != "Z":
                     push_date_time += "Z"
@@ -212,9 +209,6 @@ class DPSHelper:
             df_return = pd.DataFrame()
             for push in pushes:
                 push_current = push["current"]
-
-                if not push_current.get("datePeriod"):
-                    continue
                 push_date_time = f'{push_current["datePeriod"]["datePeriodCombinedGmt"]}'
 
                 if push_date_time[-1:] != "Z":

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -309,7 +309,7 @@ class DPSHelper:
 
         Note that plant IDs can be found by searching the plant on Enact, and series and country IDs for Enact can be found at https://enact.lcp.energy/externalinstructions.
         """
-        self.subscribe_to_multiple_series_updates(handle_data_method, plant_series_requests, parse_datetimes, True)
+        self.subscribe_to_multiple_series_updates(handle_data_method, plant_series_requests, parse_datetimes, is_for_plant_series=True)
 
     def __get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> tuple:
         subscription_id = (series_id, country_id)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -278,11 +278,8 @@ class DPSHelper:
 
         Note that plant IDs can be found by searching the plant on Enact, and series and country IDs for Enact can be found at https://enact.lcp.energy/externalinstructions.
         """
-        series_id_repeated = [series_id for _ in range(len(plant_ids))]
-        plant_id_options = [[id] for id in plant_ids]
-        self.subscribe_to_multiple_series_updates(
-            handle_data_method, series_id_repeated, plant_id_options, country_id, parse_datetimes
-        )
+        series_dictionary = {series_id: [[plant_id] for plant_id in plant_ids]}
+        self.subscribe_to_multiple_series_updates(handle_data_method, series_dictionary, country_id, parse_datetimes)
 
     def subscribe_to_multiple_series_updates_for_plant(
         self,
@@ -310,10 +307,10 @@ class DPSHelper:
 
         Note that plant IDs can be found by searching the plant on Enact, and series and country IDs for Enact can be found at https://enact.lcp.energy/externalinstructions.
         """
-        plant_id_repeated = [[plant_id] for _ in range(len(series_ids))]
-        self.subscribe_to_multiple_series_updates(
-            handle_data_method, series_ids, plant_id_repeated, country_id, parse_datetimes
-        )
+        series_dictionary = {}
+        for series_id in series_ids:
+            series_dictionary[series_id] = [[plant_id]]
+        self.subscribe_to_multiple_series_updates(handle_data_method, series_dictionary, country_id, parse_datetimes)
 
     def __get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> tuple:
         subscription_id = (series_id, country_id)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -153,7 +153,11 @@ class DPSHelper:
             df_return = pd.DataFrame()
             for push in pushes:
                 push_current = push["current"]
+
+                if not push_current.get("datePeriod"):
+                    continue
                 push_date_time = f'{push_current["datePeriod"]["datePeriodCombinedGmt"]}'
+
                 if push_date_time[-1:] != "Z":
                     push_date_time += "Z"
 
@@ -265,12 +269,12 @@ class DPSHelper:
             series_id = series_entry["seriesId"]
             if not isinstance(series_id, str):
                     raise ValueError("Please ensure that all series ids are string types.")
+            
+            series_payload = {"seriesId": series_id}
 
-            if not "countryId" in series_entry:
-                raise ValueError("Please ensure a countryId is given.")
-
-            countryId = series_entry["countryId"]
-            series_payload = {"seriesId": series_id, "countryId": countryId}
+            if "countryId" in series_entry:
+                countryId = series_entry["countryId"]
+                series_payload["countryId"] = countryId
 
             if "optionIds" in series_entry:
                 option_ids = series_entry["optionIds"]

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -44,15 +44,15 @@ class DPSHelper:
     def _fetch_bearer_token(self):
         return self.enact_credentials.bearer_token
 
-    def _add_subscription(self, join_payload: list[dict[str, str]], subscription_id: str):
+    def _add_subscription(self, request_object: list[dict[str, str]], subscription_id: str):
         self.hub_connection.send(
-            "JoinEnactPush", join_payload, lambda m: self._callback_received(m.result, subscription_id)
+            "JoinEnactPush", request_object, lambda m: self._callback_received(m.result, subscription_id)
         )
 
-    def _add_multi_series_subscription(self, join_payload: dict[str, str], subscription_ids: list[str]):
+    def _add_multi_series_subscription(self, request_object: dict[str, str], subscription_ids: list[str]):
         self.hub_connection.send(
             "JoinMultiSeriesPush",
-            join_payload,
+            request_object,
             lambda m: self._callback_received_multi_series(m.result, subscription_ids),
         )
 
@@ -91,7 +91,6 @@ class DPSHelper:
     def _callback_received_multi_series(self, m, subscription_ids: str):
         push_names = m["data"]["pushNames"]
         for subscription_id, push_name in zip(subscription_ids, push_names):
-            print(f"COMBO: {push_name} : {subscription_id}")
             self.hub_connection.on(push_name, lambda x, id_value=subscription_id: self._process_push_data(x, id_value))
 
     def _process_push_data(self, data_push, subscription_id):
@@ -205,7 +204,7 @@ class DPSHelper:
         parse_datetimes: bool = False,
     ) -> None:
         """
-        Subscribe to multiple series at once with the specified Series IDs, Option IDs if applicable and Country ID.
+        Subscribe to multiple series at once with the specified series IDs, option IDs (if applicable) and country ID.
 
         Args:
             handle_data_method `Callable`: A callback function that will be invoked when any of the series are updated.
@@ -256,7 +255,7 @@ class DPSHelper:
         parse_datetimes: bool = False,
     ) -> None:
         """
-        Subscribe to a plant series for multiple plants at once with the specified Series ID, Plant IDs and Country ID.
+        Subscribe to a plant series for multiple plants at once with the specified series ID, plant IDs and country ID.
 
         Args:
             handle_data_method `Callable`: A callback function that will be invoked when any of the series are updated.
@@ -288,7 +287,7 @@ class DPSHelper:
         parse_datetimes: bool = False,
     ) -> None:
         """
-        Subscribe to multiple plant series for a single plant at once with the specified Series IDs, Plant ID and Country ID.
+        Subscribe to multiple plant series for a single plant at once with the specified series IDs, plant ID and country ID.
 
         Args:
             handle_data_method `Callable`: A callback function that will be invoked when any of the series are updated.
@@ -309,12 +308,6 @@ class DPSHelper:
         self.subscribe_to_multiple_series_updates(
             handle_data_method, series_ids, plant_id_repeated, country_id, parse_datetimes
         )
-
-    def __get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> str:
-        subscription_id = (series_id, country_id)
-        if option_id:
-            subscription_id += tuple(option_id)
-        return subscription_id
 
     def __get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> tuple:
         subscription_id = (series_id, country_id)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -253,7 +253,7 @@ class DPSHelper:
                 The function should accept one argument, which will be the data received from the series updates.
 
             series_requests `list[dict]`: A list of dictionaries, with each element detailing a series request. Each element needs a countryId, seriesId, and if relevant, optionIds.
-                                          A series that requires options will need to have optionIds.
+                                          If subscribing to a series that requires options and it is ommited, you will subscribe to pushes for all options
 
             parse_datetimes `bool` (optional): Parse returned DataFrame index to DateTime (UTC). Defaults to False.
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -86,7 +86,7 @@ class DPSHelper:
             series_id, day_start, now, country_id, option_id, parse_datetimes=parse_datetimes
         )
         initial_series_data[self.last_updated_header] = now
-        self.data_by_subscription_id[self.__get_subscription_id(series_id, country_id, option_id)] = (
+        self.data_by_subscription_id[self._get_subscription_id(series_id, country_id, option_id)] = (
             handle_data_method,
             initial_series_data,
             parse_datetimes,
@@ -223,7 +223,7 @@ class DPSHelper:
             if not is_list_of_strings_or_empty(option_id):
                 raise ValueError("Option ID input must be a list of strings")
             request_details["OptionId"] = option_id
-        subscription_id = self.__get_subscription_id(series_id, country_id, option_id)
+        subscription_id = self._get_subscription_id(series_id, country_id, option_id)
         if subscription_id in self.data_by_subscription_id:
             return
         (handle_data_old, initial_data_from_series_api, parse_datetimes_old) = self.data_by_subscription_id.get(
@@ -311,7 +311,7 @@ class DPSHelper:
         """
         self.subscribe_to_multiple_series_updates(handle_data_method, plant_series_requests, parse_datetimes, is_for_plant_series=True)
 
-    def __get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> tuple:
+    def _get_subscription_id(self, series_id: str, country_id: str, option_id: list[str]) -> tuple:
         subscription_id = (series_id, country_id)
         if option_id:
             subscription_id += tuple(option_id)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -35,7 +35,6 @@ class DPSHelper:
         self.hub_connection.on_open(self._on_open)
         self.hub_connection.on_close((self._on_close)) #on_close(lambda: print("Connection closed")) #(self._on_close)
         self.hub_connection.on_error(lambda e: print("SignalR error:", e))
-        self.hub_connection.on_reconnect(lambda: print("reconnected!"))
 
         success = self.hub_connection.start()
         pytime.sleep(1)

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -91,6 +91,7 @@ class DPSHelper:
     def _callback_received_multi_series(self, m, subscription_ids: str):
         push_names = m["data"]["pushNames"]
         for subscription_id, push_name in zip(subscription_ids, push_names):
+            print(f"COMBO: {push_name} : {subscription_id}")
             self.hub_connection.on(push_name, lambda x, id_value=subscription_id: self._process_push_data(x, id_value))
 
     def _process_push_data(self, data_push, subscription_id):
@@ -273,8 +274,9 @@ class DPSHelper:
         Note that plant IDs can be found by searching the plant on Enact, and series and country IDs for Enact can be found at https://enact.lcp.energy/externalinstructions.
         """
         series_id_repeated = [series_id for _ in range(len(plant_ids))]
-        self.subscribe_to_multiple_series(
-            handle_data_method, series_id_repeated, plant_ids, country_id, parse_datetimes
+        plant_id_options = [[id] for id in plant_ids]
+        self.subscribe_to_multiple_series_updates(
+            handle_data_method, series_id_repeated, plant_id_options, country_id, parse_datetimes
         )
 
     def subscribe_to_multiple_series_updates_for_plant(
@@ -303,8 +305,8 @@ class DPSHelper:
 
         Note that plant IDs can be found by searching the plant on Enact, and series and country IDs for Enact can be found at https://enact.lcp.energy/externalinstructions.
         """
-        plant_id_repeated = [plant_id for _ in range(len(series_ids))]
-        self.subscribe_to_multiple_series(
+        plant_id_repeated = [[plant_id] for _ in range(len(series_ids))]
+        self.subscribe_to_multiple_series_updates(
             handle_data_method, series_ids, plant_id_repeated, country_id, parse_datetimes
         )
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -23,7 +23,7 @@ class DPSHelper:
         self.hub_connection = (
             HubConnectionBuilder()
             .with_url(
-                "https://enact-signalrhub-staging.azurewebsites.net/dataHub",  # revert
+                "https://enact-signalrhub.azurewebsites.net/dataHub",
                 options={"access_token_factory": access_token_factory},
             )
             .with_automatic_reconnect(

--- a/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/dps_helper.py
@@ -23,8 +23,8 @@ class DPSHelper:
         self.hub_connection = (
             HubConnectionBuilder()
             .with_url(
-                "https://enact-signalrhub-staging.azurewebsites.net/dataHub",
-                options={"access_token_factory": access_token_factory}
+                "https://enact-signalrhub.azurewebsites.net/dataHub",
+                 options={"access_token_factory": access_token_factory}
             )
             .with_automatic_reconnect(
                 {"type": "raw", "keep_alive_interval": 10, "reconnect_interval": 5, "max_attempts": 5}

--- a/lcpdelta_python_package/src/lcp_delta/global_helpers.py
+++ b/lcpdelta_python_package/src/lcp_delta/global_helpers.py
@@ -74,3 +74,16 @@ def get_period(datetime_input: datetime, period: int = None) -> int:
         raise TypeError("If no period is given, the inputted date must be of the type datetime")
 
     return get_period_from_datetime(datetime_input)
+
+
+def is_2d_list_of_strings(candidate):
+    if not isinstance(candidate, list):
+        return False
+
+    for item in candidate:
+        if not isinstance(item, list):
+            return False
+        if not all(isinstance(inner_item, str) for inner_item in item):
+            return False
+
+    return True

--- a/lcpdelta_python_package/tests/integration/test_api_boa.py
+++ b/lcpdelta_python_package/tests/integration/test_api_boa.py
@@ -26,7 +26,7 @@ async def test_get_bm_data_by_period_async():
     assert [column in res["acceptedOffers"].columns for column in expected_bsad_columns]
 
     assert res["tableBids"].index[0] == "T_GNAPW-1"
-    assert res["tableBids"].iloc[0]["volume"] == -5.016666666666667
+    assert res["tableBids"].iloc[0]["volume"] == -5.0
     assert res["tableBids"].iloc[0]["bidPrice"] == -92.78
 
     assert res["tableOffers"].index[0] == "T_GNAPW-1"
@@ -48,7 +48,7 @@ def test_get_bm_data_by_period_sync():
     assert [column in res["acceptedOffers"].columns for column in expected_bsad_columns]
 
     assert res["tableBids"].index[0] == "T_GNAPW-1"
-    assert res["tableBids"].iloc[0]["volume"] == -5.016666666666667
+    assert res["tableBids"].iloc[0]["volume"] == -5.0
     assert res["tableBids"].iloc[0]["bidPrice"] == -92.78
 
     assert res["tableOffers"].index[0] == "T_GNAPW-1"

--- a/lcpdelta_python_package/tests/integration/test_api_leaderboard.py
+++ b/lcpdelta_python_package/tests/integration/test_api_leaderboard.py
@@ -65,7 +65,7 @@ v2_columns = [ # Plant - Co-located fuel, Profit - CM are optional extras, also 
     'Profit - Frequency',
     'Profit - Reserve',
     'Profit - CM',
-    'Profit - Non-Delivery Charge',
+    'Profit - BM Non-Delivery Charge',
     'BM Profit Breakdown - Bids',
     'BM Profit Breakdown - Offers',
     'BM Profit Breakdown - System',

--- a/lcpdelta_python_package/tests/integration/test_dps.py
+++ b/lcpdelta_python_package/tests/integration/test_dps.py
@@ -64,31 +64,10 @@ def test_subscribe_to_multi_series_updates():
 
     system_request = [
       {"seriesId": "AFRRVolumeRealtime", "optionIds": [["Up"], ["Down"]], "countryId": "Belgium"},
-      {"seriesId": "ImbalancePriceRealtime", "countryId": "Belgium"},
     ]
 
     try:
         enact_dps_helper.subscribe_to_multiple_series_updates(handle_data_method, system_request, parse_datetimes=True)
-    except Exception as e:
-        pytest.fail(f"Subscription to series updates failed: {e}")
-
-    try:
-        enact_dps_helper.terminate_hub_connection()
-    except Exception as e:
-        pytest.fail(f"Termination of the connection failed: {e}")
-
-
-def test_subscribe_to_multi_plant_series_updates():
-    enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
-    assert enact_dps_helper.hub_connection is not None
-
-    plant_request = [
-        {"seriesId": "RollingBidsAccepted", "optionIds": ["T_CRUA-2", "T_CRUA-1"], "countryId": "Gb"},
-        {"seriesId": "RollingOffersAccepted", "optionIds": ["CCGT", "Battery", ], "countryId": "Gb"},
-    ]
-
-    try:
-        enact_dps_helper.subscribe_to_multiple_plant_series_updates(handle_data_method, plant_request, parse_datetimes=True)
     except Exception as e:
         pytest.fail(f"Subscription to series updates failed: {e}")
 

--- a/lcpdelta_python_package/tests/integration/test_dps.py
+++ b/lcpdelta_python_package/tests/integration/test_dps.py
@@ -62,19 +62,15 @@ def test_subscribe_to_multi_series_updates():
     enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
     assert enact_dps_helper.hub_connection is not None
 
-    series_dictionary = {
-        "AFRRVolumeRealtime": [["Up"], ["Down"]],
-        "ImbalancePriceRealtime": None,
-        "AlphaFactor": None,
-    }
+    system_request = [
+      {"seriesId": "AFRRVolumeRealtime", "optionIds": [["Up"], ["Down"]], "countryId": "Belgium"},
+      {"seriesId": "ImbalancePriceRealtime", "countryId": "Belgium"},
+    ]
 
     try:
-        enact_dps_helper.subscribe_to_multiple_series_updates(handle_data_method, series_dictionary, "Belgium")
+        enact_dps_helper.subscribe_to_multiple_series_updates(handle_data_method, system_request, parse_datetimes=True)
     except Exception as e:
         pytest.fail(f"Subscription to series updates failed: {e}")
-
-    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("AFRRVolumeRealtime", "Belgium", ["Up"])
-    assert subscription_id in enact_dps_helper.data_by_subscription_id
 
     try:
         enact_dps_helper.terminate_hub_connection()
@@ -82,39 +78,19 @@ def test_subscribe_to_multi_series_updates():
         pytest.fail(f"Termination of the connection failed: {e}")
 
 
-def test_subscribe_to_plant_multi_series_updates():
+def test_subscribe_to_multi_plant_series_updates():
     enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
     assert enact_dps_helper.hub_connection is not None
 
+    plant_request = [
+        {"seriesId": "RollingBidsAccepted", "optionIds": ["T_CRUA-2", "T_CRUA-1"], "countryId": "Gb"},
+        {"seriesId": "RollingOffersAccepted", "optionIds": ["CCGT", "Battery", ], "countryId": "Gb"},
+    ]
+
     try:
-        enact_dps_helper.subscribe_to_multiple_series_updates_for_plant(
-            handle_data_method, ["RollingOffersAccepted", "RollingBidsAccepted"], "T_DAMC-1"
-        )
+        enact_dps_helper.subscribe_to_multiple_plant_series_updates(handle_data_method, plant_request, parse_datetimes=True)
     except Exception as e:
         pytest.fail(f"Subscription to series updates failed: {e}")
-
-    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("RollingOffersAccepted", "Gb", ["T_DAMC-1"])
-    assert subscription_id in enact_dps_helper.data_by_subscription_id
-
-    try:
-        enact_dps_helper.terminate_hub_connection()
-    except Exception as e:
-        pytest.fail(f"Termination of the connection failed: {e}")
-
-
-def test_subscribe_to_series_multi_plant_updates():
-    enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
-    assert enact_dps_helper.hub_connection is not None
-
-    try:
-        enact_dps_helper.subscribe_to_series_updates_for_multiple_plants(
-            handle_data_method, "RollingOffersAccepted", ["T_ROCK-1", "T_CNQPS-2", "T_CNQPS-4"]
-        )
-    except Exception as e:
-        pytest.fail(f"Subscription to series updates failed: {e}")
-
-    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("RollingOffersAccepted", "Gb", ["T_ROCK-1"])
-    assert subscription_id in enact_dps_helper.data_by_subscription_id
 
     try:
         enact_dps_helper.terminate_hub_connection()

--- a/lcpdelta_python_package/tests/integration/test_dps.py
+++ b/lcpdelta_python_package/tests/integration/test_dps.py
@@ -56,3 +56,67 @@ def test_subscribe_to_notifications():
         enact_dps_helper.terminate_hub_connection()
     except Exception as e:
         pytest.fail(f"Termination of the connection failed: {e}")
+
+
+def test_subscribe_to_multi_series_updates():
+    enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
+    assert enact_dps_helper.hub_connection is not None
+
+    series_dictionary = {
+        "AFRRVolumeRealtime": [["Up"], ["Down"]],
+        "ImbalancePriceRealtime": None,
+        "AlphaFactor": None,
+    }
+
+    try:
+        enact_dps_helper.subscribe_to_multiple_series_updates(handle_data_method, series_dictionary, "Belgium")
+    except Exception as e:
+        pytest.fail(f"Subscription to series updates failed: {e}")
+
+    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("AFRRVolumeRealtime", "Belgium", ["Up"])
+    assert subscription_id in enact_dps_helper.data_by_subscription_id
+
+    try:
+        enact_dps_helper.terminate_hub_connection()
+    except Exception as e:
+        pytest.fail(f"Termination of the connection failed: {e}")
+
+
+def test_subscribe_to_plant_multi_series_updates():
+    enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
+    assert enact_dps_helper.hub_connection is not None
+
+    try:
+        enact_dps_helper.subscribe_to_multiple_series_updates_for_plant(
+            handle_data_method, ["RollingOffersAccepted", "RollingBidsAccepted"], "T_DAMC-1"
+        )
+    except Exception as e:
+        pytest.fail(f"Subscription to series updates failed: {e}")
+
+    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("RollingOffersAccepted", "Gb", ["T_DAMC-1"])
+    assert subscription_id in enact_dps_helper.data_by_subscription_id
+
+    try:
+        enact_dps_helper.terminate_hub_connection()
+    except Exception as e:
+        pytest.fail(f"Termination of the connection failed: {e}")
+
+
+def test_subscribe_to_series_multi_plant_updates():
+    enact_dps_helper = enact.DPSHelper(enact_username, enact_public_api_key)
+    assert enact_dps_helper.hub_connection is not None
+
+    try:
+        enact_dps_helper.subscribe_to_series_updates_for_multiple_plants(
+            handle_data_method, "RollingOffersAccepted", ["T_ROCK-1", "T_CNQPS-2", "T_CNQPS-4"]
+        )
+    except Exception as e:
+        pytest.fail(f"Subscription to series updates failed: {e}")
+
+    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("RollingOffersAccepted", "Gb", ["T_ROCK-1"])
+    assert subscription_id in enact_dps_helper.data_by_subscription_id
+
+    try:
+        enact_dps_helper.terminate_hub_connection()
+    except Exception as e:
+        pytest.fail(f"Termination of the connection failed: {e}")

--- a/lcpdelta_python_package/tests/integration/test_dps.py
+++ b/lcpdelta_python_package/tests/integration/test_dps.py
@@ -19,7 +19,7 @@ def test_subscribe_to_series_updates():
     except Exception as e:
         pytest.fail(f"Subscription to series updates failed: {e}")
 
-    subscription_id = enact_dps_helper.__get_subscription_id("RealtimeDemand", "Gb", None)
+    subscription_id = enact_dps_helper._get_subscription_id("RealtimeDemand", "Gb", None)
     assert subscription_id in enact_dps_helper.data_by_subscription_id
 
     try:

--- a/lcpdelta_python_package/tests/integration/test_dps.py
+++ b/lcpdelta_python_package/tests/integration/test_dps.py
@@ -19,7 +19,7 @@ def test_subscribe_to_series_updates():
     except Exception as e:
         pytest.fail(f"Subscription to series updates failed: {e}")
 
-    subscription_id = enact_dps_helper._DPSHelper__get_subscription_id("RealtimeDemand", "Gb", None)
+    subscription_id = enact_dps_helper.__get_subscription_id("RealtimeDemand", "Gb", None)
     assert subscription_id in enact_dps_helper.data_by_subscription_id
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy",
     "pandas",
     "requests",
-    "signalrcore",
+    "signalrcore==0.9.5",
     "matplotlib",
     "httpx",
     "tenacity"
@@ -39,7 +39,7 @@ dev = [
     "nbval",
     "pandas",
     "numpy",
-    "signalrcore",
+    "signalrcore==0.9.5",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dev = [
     "jupyter",
     "nbval",
     "pandas",
-    "numpy"
+    "numpy",
+    "signalrcore",
 ]
 
 [project.urls]


### PR DESCRIPTION
**This must not be released until Enact's SignalR Hub is released with the corresponding functionality.**

Add a helper function to the DPS helper to subscribe to multiple Enact series at once, by specifying the Series IDs, Country ID and Option IDs (if applicable).

Additionally, add streamlined helpers for:

- Subscribing to a plant series for multiple plant options
- Subscribing to multiple plant series for a single plant

