### PR TITLE
Add co-located fuel and aggregate options

### DIFF
--- a/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
@@ -946,6 +946,8 @@ class APIHelper(APIHelperBase):
         include_capacity_market_revenues=False,
         ancillary_profit_aggregation="FrequencyAndReserve",
         group_dx=False,
+        aggregate=None,
+        show_co_located_fuels=False,
     ) -> pd.DataFrame:
         """Gets leaderboard data for a given date range.
 
@@ -968,7 +970,10 @@ class APIHelper(APIHelperBase):
             ancillary_profit_aggregation `str` (optional): The aggregation option for ancillary profits. Options are: "FrequencyAndReserve", "ByProduct", and "ByDirection". Defaults to "FrequencyAndReserve".
 
             group_dx `bool` (optional): When set to true, DC, DR, and DL profits will be grouped into "Dx". Defaults to False.
-        """
+
+            aggregate (optional, str): Aggregation level ("Day", "Week", "Month"). Defaults to None. For the given date range, data is aggregated by the specified period (e.g., "Month" splits the original date range into months creating rows in the dataframe for each month). An aggregate column indicates the start date of each aggregation.
+
+            show_co_located_fuels `bool` (optional): When set to true, a column will show the fuel types of co-located plants. Defaults to False."""
         request_body = leaderboard_service.generate_request_v2(
             date_from,
             date_to,
@@ -979,6 +984,8 @@ class APIHelper(APIHelperBase):
             include_capacity_market_revenues,
             ancillary_profit_aggregation,
             group_dx,
+            aggregate,
+            show_co_located_fuels,
         )
         response = self._post_request(ep.LEADERBOARD_V2, request_body)
         return leaderboard_service.process_response(response, type)
@@ -994,6 +1001,8 @@ class APIHelper(APIHelperBase):
         include_capacity_market_revenues=False,
         ancillary_profit_aggregation="FrequencyAndReserve",
         group_dx=False,
+        aggregate=None,
+        show_co_located_fuels=False,
     ) -> pd.DataFrame:
         """An asynchronous version of `get_leaderboard_data`."""
         request_body = leaderboard_service.generate_request_v2(
@@ -1006,6 +1015,8 @@ class APIHelper(APIHelperBase):
             include_capacity_market_revenues,
             ancillary_profit_aggregation,
             group_dx,
+            aggregate,
+            show_co_located_fuels,
         )
         response = await self._post_request_async(ep.LEADERBOARD_V2, request_body)
         return leaderboard_service.process_response(response, type)

--- a/lcpdelta_python_package/src/lcp_delta/enact/services/leaderboard_service.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/services/leaderboard_service.py
@@ -39,6 +39,8 @@ def generate_request_v2(
     include_capacity_market_revenues=False,
     ancillary_profit_aggregation="FrequencyAndReserve",
     group_dx=False,
+    aggregate=None,
+    show_co_located_fuels=False,
 ) -> dict:
     date_from, date_to = convert_datetimes_to_iso(date_from, date_to)
     return {
@@ -51,6 +53,8 @@ def generate_request_v2(
         "IncludeCmRevenues": include_capacity_market_revenues,
         "AncillaryProfitAggregation": ancillary_profit_aggregation,
         "GroupDx": group_dx,
+        "Aggregate": aggregate,
+        "ShowCoLocatedFuels": show_co_located_fuels,
     }
 
 

--- a/lcpdelta_python_package/tests/integration/test_api_ancillary.py
+++ b/lcpdelta_python_package/tests/integration/test_api_ancillary.py
@@ -12,8 +12,6 @@ def teardown_function():
 ancillary_columns = [
     "acceptanceRatio",
     "marketName",
-    "biddingLevelName",
-    "marketProductId",
     "auctionId",
     "deliveryStartGmt",
     "deliveryEndGmt",
@@ -29,7 +27,6 @@ ancillary_columns = [
     "volumeAccepted",
     "availabilityFee",
     "reasonRejected",
-    "settlementCurrency",
     "optimiser",
     "enactId",
     "owner",
@@ -105,7 +102,6 @@ async def test_get_DCH_contracts_async():
 
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DCH_contracts_sync():
@@ -115,7 +111,6 @@ def test_get_DCH_contracts_sync():
     assert res.index[0] == "6111407"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -126,7 +121,6 @@ async def test_get_DCL_contracts_async():
     assert res.index[0] == "6111406"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DCL_contracts_sync():
@@ -136,7 +130,6 @@ def test_get_DCL_contracts_sync():
     assert res.index[0] == "6111406"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -147,7 +140,6 @@ async def test_get_DMH_contracts_async():
     assert res.index[0] == "6112209"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DMH_contracts_sync():
@@ -157,7 +149,6 @@ def test_get_DMH_contracts_sync():
     assert res.index[0] == "6112209"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -168,7 +159,6 @@ async def test_get_DML_contracts_async():
     assert res.index[0] == "6111969"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DML_contracts_sync():
@@ -178,7 +168,6 @@ def test_get_DML_contracts_sync():
     assert res.index[0] == "6111969"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -189,7 +178,6 @@ async def test_get_DRH_contracts_async():
     assert res.index[0] == "6111970"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DRH_contracts_sync():
@@ -199,7 +187,6 @@ def test_get_DRH_contracts_sync():
     assert res.index[0] == "6111970"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -210,7 +197,6 @@ async def test_get_DRL_contracts_async():
     assert res.index[0] == "6111971"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DRL_contracts_sync():
@@ -220,7 +206,6 @@ def test_get_DRL_contracts_sync():
     assert res.index[0] == "6111971"
     missing_columns = set(ancillary_columns) - set(res.columns)
     assert not missing_columns, f"Missing columns: {missing_columns}"
-    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -291,7 +276,8 @@ async def test_get_SFFR_contracts_async():
     assert res.iloc[0]["enactId"] == "IPSWA-1"
     assert res.iloc[0]["offeredVolume"] == 20.0
     assert res.iloc[0]["offeredPrice"] == 0.01
-    assert all(column in res.columns for column in sffr_columns)
+    missing_columns = set(sffr_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
 
 
 def test_get_SFFR_contracts_sync():
@@ -300,7 +286,8 @@ def test_get_SFFR_contracts_sync():
     assert res.iloc[0]["enactId"] == "IPSWA-1"
     assert res.iloc[0]["offeredVolume"] == 20.0
     assert res.iloc[0]["offeredPrice"] == 0.01
-    assert all(column in res.columns for column in sffr_columns)
+    missing_columns = set(sffr_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
 
 
 @pytest.mark.asyncio
@@ -310,7 +297,8 @@ async def test_get_STOR_contracts_async():
     assert res.iloc[0]["tenderRoundId"] == "TRN-2949"
     assert res.iloc[0]["clearingVolume"] == 60.0
     assert res.iloc[0]["clearingPrice"] == 0.72
-    assert all(column in res.columns for column in stor_columns)
+    missing_columns = set(stor_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
 
 
 def test_get_STOR_contracts_sync():
@@ -319,4 +307,5 @@ def test_get_STOR_contracts_sync():
     assert res.iloc[0]["tenderRoundId"] == "TRN-2949"
     assert res.iloc[0]["clearingVolume"] == 60.0
     assert res.iloc[0]["clearingPrice"] == 0.72
-    assert all(column in res.columns for column in stor_columns)
+    missing_columns = set(stor_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"

--- a/lcpdelta_python_package/tests/integration/test_api_ancillary.py
+++ b/lcpdelta_python_package/tests/integration/test_api_ancillary.py
@@ -102,7 +102,10 @@ async def test_get_DCH_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111407"
-    assert all(column in res.columns for column in ancillary_columns)
+
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DCH_contracts_sync():
@@ -110,7 +113,9 @@ def test_get_DCH_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111407"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -119,7 +124,9 @@ async def test_get_DCL_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111406"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DCL_contracts_sync():
@@ -127,7 +134,9 @@ def test_get_DCL_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111406"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -136,7 +145,9 @@ async def test_get_DMH_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6112209"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DMH_contracts_sync():
@@ -144,7 +155,9 @@ def test_get_DMH_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6112209"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -153,7 +166,9 @@ async def test_get_DML_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111969"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DML_contracts_sync():
@@ -161,7 +176,9 @@ def test_get_DML_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111969"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -170,7 +187,9 @@ async def test_get_DRH_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111970"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DRH_contracts_sync():
@@ -178,7 +197,9 @@ def test_get_DRH_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111970"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio
@@ -187,7 +208,9 @@ async def test_get_DRL_contracts_async():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111971"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 def test_get_DRL_contracts_sync():
@@ -195,7 +218,9 @@ def test_get_DRL_contracts_sync():
 
     assert res.index.name == "orderId"
     assert res.index[0] == "6111971"
-    assert all(column in res.columns for column in ancillary_columns)
+    missing_columns = set(ancillary_columns) - set(res.columns)
+    assert not missing_columns, f"Missing columns: {missing_columns}"
+    # assert all(column in res.columns for column in ancillary_columns)
 
 
 @pytest.mark.asyncio

--- a/lcpdelta_python_package/tests/integration/test_api_boa.py
+++ b/lcpdelta_python_package/tests/integration/test_api_boa.py
@@ -26,7 +26,7 @@ async def test_get_bm_data_by_period_async():
     assert [column in res["acceptedOffers"].columns for column in expected_bsad_columns]
 
     assert res["tableBids"].index[0] == "T_GNAPW-1"
-    assert res["tableBids"].iloc[0]["volume"] == -5.016666666666667
+    assert res["tableBids"].iloc[0]["volume"] == -5.0
     assert res["tableBids"].iloc[0]["bidPrice"] == -92.78
 
     assert res["tableOffers"].index[0] == "T_GNAPW-1"
@@ -48,7 +48,7 @@ def test_get_bm_data_by_period_sync():
     assert [column in res["acceptedOffers"].columns for column in expected_bsad_columns]
 
     assert res["tableBids"].index[0] == "T_GNAPW-1"
-    assert res["tableBids"].iloc[0]["volume"] == -5.016666666666667
+    assert res["tableBids"].iloc[0]["volume"] == -5.0
     assert res["tableBids"].iloc[0]["bidPrice"] == -92.78
 
     assert res["tableOffers"].index[0] == "T_GNAPW-1"

--- a/lcpdelta_python_package/tests/integration/test_api_leaderboard.py
+++ b/lcpdelta_python_package/tests/integration/test_api_leaderboard.py
@@ -38,6 +38,11 @@ expected_columns = [
     "Wholesale Volume - Total",
 ]
 
+v2_columns = [
+    "Plant - Co-located fuel",
+    "Aggregate",
+]
+
 
 @pytest.mark.asyncio
 async def test_get_leaderboard_data_legacy_async():
@@ -81,6 +86,7 @@ async def test_get_leaderboard_data_async():
     )
 
     assert [column in res.columns for column in expected_columns]
+    assert [column in res.columns for column in v2_columns]
 
 
 def test_get_leaderboard_data_sync():
@@ -97,3 +103,4 @@ def test_get_leaderboard_data_sync():
     )
 
     assert [column in res.columns for column in expected_columns]
+    assert [column in res.columns for column in v2_columns]


### PR DESCRIPTION
PR from @Bogier333 (note to add alternative account to repo after Christmas) adding new co-located fuel and time aggregate options corresponding to recent updates to the Enact Leaderboard API