### PR TITLE
Adding default german indices to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.vscode/launch.json

--- a/lcpdelta_python_package/src/lcp_delta/common/api_helper_base.py
+++ b/lcpdelta_python_package/src/lcp_delta/common/api_helper_base.py
@@ -27,7 +27,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        async with httpx.AsyncClient(verify=True, timeout=timeout) as client:
+        async with httpx.AsyncClient(verify=False, timeout=timeout) as client:
             response = await client.post(endpoint, json=request_body, headers=self._get_headers())
 
         # if bearer token expired, refresh and retry
@@ -46,7 +46,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        with httpx.Client(verify=True, timeout=timeout) as client:
+        with httpx.Client(verify=False, timeout=timeout) as client:
             response = client.post(endpoint, json=request_body, headers=self._get_headers())
 
         # if bearer token expired, refresh and retry
@@ -65,7 +65,7 @@ class APIHelperBase(ABC):
         """
         self._refresh_headers(headers)
 
-        async with httpx.AsyncClient(verify=True, timeout=self.timeout) as client:
+        async with httpx.AsyncClient(verify=False, timeout=self.timeout) as client:
             return await client.post(endpoint, json=request_body, headers=headers)
 
     @UNAUTHORISED_INCLUSIVE_RETRY_POLICY
@@ -75,7 +75,7 @@ class APIHelperBase(ABC):
         """
         self._refresh_headers(headers)
 
-        with httpx.Client(verify=True, timeout=self.timeout) as client:
+        with httpx.Client(verify=False, timeout=self.timeout) as client:
             return client.post(endpoint, json=request_body, headers=headers)
 
     def _get_headers(self):

--- a/lcpdelta_python_package/src/lcp_delta/common/api_helper_base.py
+++ b/lcpdelta_python_package/src/lcp_delta/common/api_helper_base.py
@@ -27,7 +27,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        async with httpx.AsyncClient(verify=False, timeout=timeout) as client:
+        async with httpx.AsyncClient(verify=True, timeout=timeout) as client:
             response = await client.post(endpoint, json=request_body, headers=self._get_headers())
 
         # if bearer token expired, refresh and retry
@@ -46,7 +46,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        with httpx.Client(verify=False, timeout=timeout) as client:
+        with httpx.Client(verify=True, timeout=timeout) as client:
             response = client.post(endpoint, json=request_body, headers=self._get_headers())
 
         # if bearer token expired, refresh and retry
@@ -65,7 +65,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        async with httpx.AsyncClient(verify=False, timeout=timeout) as client:
+        async with httpx.AsyncClient(verify=True, timeout=timeout) as client:
             response = await client.get(endpoint, params=params, headers=self._get_headers())
 
         if response.status_code == 401 and "WWW-Authenticate" in response.headers:
@@ -83,7 +83,7 @@ class APIHelperBase(ABC):
         """
         timeout = httpx.Timeout(5.0, read=60.0) if long_timeout else self.timeout
 
-        with httpx.Client(verify=False, timeout=timeout) as client:
+        with httpx.Client(verify=True, timeout=timeout) as client:
             response = client.get(endpoint, params=params, headers=self._get_headers())
 
         if response.status_code == 401 and "WWW-Authenticate" in response.headers:

--- a/lcpdelta_python_package/src/lcp_delta/common/credentials_holder.py
+++ b/lcpdelta_python_package/src/lcp_delta/common/credentials_holder.py
@@ -32,7 +32,7 @@ class CredentialsHolder:
         Gets the bearer token for authentication, based on the username and public API key associated with the instance.
         """
         endpoint = f"{constants.MAIN_BASE_URL}/auth/token"
-        with httpx.Client(verify=False) as client:
+        with httpx.Client(verify=True) as client:
             response = client.post(endpoint, headers=self._auth_headers, json=self._credentials_payload)
 
         self.bearer_token = response.text
@@ -46,7 +46,7 @@ class CredentialsHolder:
             `UsageInfo`: An object holding the monthly quota, remaining allowance, and date that monthly usage was last last refreshed.
         """
         endpoint = f"{constants.MAIN_BASE_URL}/auth/usage_v2"
-        with httpx.Client(verify=False) as client:
+        with httpx.Client(verify=True) as client:
             response = client.post(endpoint, headers=self._auth_headers, json=self._credentials_payload)
 
         response_data = json.loads(response.content)

--- a/lcpdelta_python_package/src/lcp_delta/common/credentials_holder.py
+++ b/lcpdelta_python_package/src/lcp_delta/common/credentials_holder.py
@@ -32,7 +32,7 @@ class CredentialsHolder:
         Gets the bearer token for authentication, based on the username and public API key associated with the instance.
         """
         endpoint = f"{constants.MAIN_BASE_URL}/auth/token"
-        with httpx.Client(verify=True) as client:
+        with httpx.Client(verify=False) as client:
             response = client.post(endpoint, headers=self._auth_headers, json=self._credentials_payload)
 
         self.bearer_token = response.text
@@ -46,7 +46,7 @@ class CredentialsHolder:
             `UsageInfo`: An object holding the monthly quota, remaining allowance, and date that monthly usage was last last refreshed.
         """
         endpoint = f"{constants.MAIN_BASE_URL}/auth/usage_v2"
-        with httpx.Client(verify=True) as client:
+        with httpx.Client(verify=False) as client:
             response = client.post(endpoint, headers=self._auth_headers, json=self._credentials_payload)
 
         response_data = json.loads(response.content)

--- a/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
@@ -15,6 +15,7 @@ from lcp_delta.enact.services import day_ahead_service
 from lcp_delta.enact.services import epex_service
 from lcp_delta.enact.services import hof_service
 from lcp_delta.enact.services import leaderboard_service
+from lcp_delta.enact.services import index_service
 from lcp_delta.enact.services import news_table_service
 from lcp_delta.enact.services import nordpool_service
 from lcp_delta.enact.services import plant_service
@@ -1036,6 +1037,36 @@ class APIHelper(APIHelperBase):
         )
         response = await self._post_request_async(ep.LEADERBOARD_V2, request_body)
         return leaderboard_service.process_response(response, type)
+
+    def get_german_index_data(
+        self,
+        date_from: datetime,
+        date_to: datetime,
+        index_id: str,
+        normalisation="PoundPerKwPerYear",
+        granularity="Week",
+    ) -> pd.DataFrame:
+        """Gets german index data for a given date range and index ID.
+
+        Args:
+            date_from `datetime.datetime`: The start date.
+
+            date_to `datetime.datetime`: The end date. Set equal to the start date to return data for a given day.
+
+            index_id `str`: The index ID denoting which index to get data for. Index ID's of the default german indices can be found via the #### method.
+
+            normalisation `str` (optional): The normalisation to apply. "Euro", "EuroPerMw", "EuroPerMwh" or "EuroPerKwPerYear" (default).
+
+            granularity `str` (optional): The granularity of the data. "Day", "Week" (default) or "Month". """
+        request_body = index_service.generate_request(
+            date_from,
+            date_to,
+            index_id,
+            normalisation,
+            granularity,
+        )
+        response = self._post_request(ep.EUROPE_INDEX, request_body)
+        return index_service.process_response(response)
 
     def get_ancillary_contract_data(
         self,

--- a/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
@@ -1079,7 +1079,7 @@ class APIHelper(APIHelperBase):
 
             normalisation `str` (optional): The normalisation to apply. "Euro", "EuroPerMw", "EuroPerMwh" or "EuroPerKwPerYear" (default).
 
-            granularity `str` (optional): The granularity of the data. "Day", "Week" (default) or "Month". """
+            granularity `str` (optional): The granularity of the data. "Day", "Week" (default), "Month" or "Year". """
         request_body = index_service.generate_request(
             date_from,
             date_to,

--- a/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/api_helper.py
@@ -1048,6 +1048,18 @@ class APIHelper(APIHelperBase):
         response = await self._post_request_async(ep.LEADERBOARD_V2, request_body)
         return leaderboard_service.process_response(response, type)
 
+    def get_default_german_indices(self) -> pd.DataFrame:
+        """ Get the defining information of the default german indices, including the GUID that allows querying of that indices data via `get_german_index_data` """
+
+        response = self._get_request(ep.EUROPE_INDEX_DEFAULT_INDICES)
+        return index_service.process_default_index_info_response(response)
+
+    async def get_default_german_indices_async(self) -> pd.DataFrame:
+        """An asynchronous version of `get_default_german_indices`."""
+
+        response = await self._get_request_async(ep.EUROPE_INDEX_DEFAULT_INDICES)
+        return index_service.process_default_index_info_response(response)
+
     def get_german_index_data(
         self,
         date_from: datetime,
@@ -1075,8 +1087,27 @@ class APIHelper(APIHelperBase):
             normalisation,
             granularity,
         )
-        response = self._post_request(ep.EUROPE_INDEX, request_body)
-        return index_service.process_response(response)
+        response = self._post_request(ep.EUROPE_INDEX_DATA, request_body)
+        return index_service.process_index_data_response(response)
+
+    async def get_german_index_data_async(
+        self,
+        date_from: datetime,
+        date_to: datetime,
+        index_id: str,
+        normalisation="PoundPerKwPerYear",
+        granularity="Week",
+    ) -> pd.DataFrame:
+        """An asynchronous version of `get_german_index_data`."""
+        request_body = index_service.generate_request(
+            date_from,
+            date_to,
+            index_id,
+            normalisation,
+            granularity,
+        )
+        response = await self._post_request_async(ep.EUROPE_INDEX_DATA, request_body)
+        return index_service.process_index_data_response(response)
 
     def get_ancillary_contract_data(
         self,

--- a/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
@@ -4,6 +4,7 @@ from lcp_delta.enact.loader import get_base_endpoints
 base_endpoints = get_base_endpoints()
 
 MAIN_BASE_URL = base_endpoints.MAIN_BASE_URL
+MAIN_BASE_URL = "https://localhost:44312"
 SERIES_BASE_URL = base_endpoints.SERIES_BASE_URL
 
 SERIES_DATA = f"{MAIN_BASE_URL}/EnactAPI/Series/Data_V2"
@@ -26,6 +27,8 @@ BOA = f"{MAIN_BASE_URL}/EnactAPI/BOA/Data"
 
 LEADERBOARD_V1 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v1/data"
 LEADERBOARD_V2 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v2/data"
+
+EUROPE_INDEX = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/data"
 
 ANCILLARY = f"{MAIN_BASE_URL}/EnactAPI/Ancillary/Data"
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
@@ -4,7 +4,6 @@ from lcp_delta.enact.loader import get_base_endpoints
 base_endpoints = get_base_endpoints()
 
 MAIN_BASE_URL = base_endpoints.MAIN_BASE_URL
-MAIN_BASE_URL = "https://localhost:44312"
 SERIES_BASE_URL = base_endpoints.SERIES_BASE_URL
 
 SERIES_DATA = f"{MAIN_BASE_URL}/EnactAPI/Series/Data_V2"

--- a/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
@@ -28,7 +28,8 @@ BOA = f"{MAIN_BASE_URL}/EnactAPI/BOA/Data"
 LEADERBOARD_V1 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v1/data"
 LEADERBOARD_V2 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v2/data"
 
-EUROPE_INDEX = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/data"
+EUROPE_INDEX_DATA = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/data"
+EUROPE_INDEX_DEFAULT_INDICES = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/defaultIndices"
 
 ANCILLARY = f"{MAIN_BASE_URL}/EnactAPI/Ancillary/Data"
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/endpoints.py
@@ -27,8 +27,8 @@ BOA = f"{MAIN_BASE_URL}/EnactAPI/BOA/Data"
 LEADERBOARD_V1 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v1/data"
 LEADERBOARD_V2 = f"{MAIN_BASE_URL}/EnactAPI/Leaderboard/v2/data"
 
-EUROPE_INDEX_DATA = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/data"
-EUROPE_INDEX_DEFAULT_INDICES = f"{MAIN_BASE_URL}/EnactAPI/EuropeIndex/defaultIndices"
+EUROPE_INDEX_DATA = f"{SERIES_BASE_URL}/api/EuropeIndexData"
+EUROPE_INDEX_DEFAULT_INDICES = f"{SERIES_BASE_URL}/api/EuropeIndexDefaultIndexInformation"
 
 ANCILLARY = f"{MAIN_BASE_URL}/EnactAPI/Ancillary/Data"
 

--- a/lcpdelta_python_package/src/lcp_delta/enact/services/index_service.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/services/index_service.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+from datetime import datetime
+
+from lcp_delta.global_helpers import convert_datetimes_to_iso
+from lcp_delta.enact.helpers import convert_embedded_list_to_df
+
+
+def generate_request(
+    date_from: datetime,
+    date_to: datetime,
+    index_id: str,
+    normalisation="PoundPerKwPerYear",
+    granularity="Week",
+) -> dict:
+    date_from, date_to = convert_datetimes_to_iso(date_from, date_to)
+    return {
+        "From": date_from,
+        "To": date_to,
+        "IndexId": index_id,
+        "SelectedNormalisation": normalisation,
+        "SelectedGranularity": granularity,
+    }
+
+def process_response(response: dict) -> pd.DataFrame:
+    return convert_embedded_list_to_df(response, "Day")

--- a/lcpdelta_python_package/src/lcp_delta/enact/services/index_service.py
+++ b/lcpdelta_python_package/src/lcp_delta/enact/services/index_service.py
@@ -10,7 +10,7 @@ def generate_request(
     date_from: datetime,
     date_to: datetime,
     index_id: str,
-    normalisation="PoundPerKwPerYear",
+    normalisation="EuroPerKwPerYear",
     granularity="Week",
 ) -> dict:
     date_from, date_to = convert_datetimes_to_iso(date_from, date_to)
@@ -22,5 +22,9 @@ def generate_request(
         "SelectedGranularity": granularity,
     }
 
-def process_response(response: dict) -> pd.DataFrame:
+
+def process_default_index_info_response(response: dict) -> pd.DataFrame:
+    return convert_embedded_list_to_df(response)
+
+def process_index_data_response(response: dict) -> pd.DataFrame:
     return convert_embedded_list_to_df(response, "Day")

--- a/lcpdelta_python_package/tests/integration/test_api_german_index.py
+++ b/lcpdelta_python_package/tests/integration/test_api_german_index.py
@@ -3,13 +3,10 @@ import time
 from datetime import date
 from tests.integration import enact_api_helper
 
-
 def teardown_function():
     time.sleep(2)
 
-
-expected_columns = [
-    "Day",
+expected_data_columns = [
     "Total",
     "Fcr",
     "AfrrCapacity",
@@ -18,64 +15,25 @@ expected_columns = [
     "IntradayContinuous"
 ]
 
-
-@pytest.mark.asyncio
-async def test_get_index():
-
+def test_get_index_sync():
     response_dataframe = enact_api_helper.get_german_index_data(
         date(2024,1,21),
         date(2024,1,23),
-        'DA, IDC, aFRR Energy 1Hr 2 Cycle 50MW',
+        '0196fb45-e59c-44a9-907a-cd76033bd504',
         granularity="Day",
         normalisation = "EuroPerMw"
     )
 
-    assert [column in response_dataframe.columns for column in expected_columns]
-
-
-def test_get_leaderboard_data_legacy_sync():
-    res = enact_api_helper.get_leaderboard_data_legacy(
-        date(2024, 8, 1),
-        date(2024, 8, 3),
-        "Plant",
-        "PoundPerMwPerH",
-        "WeightedAverageDayAheadPrice",
-        "DayAheadForward",
-    )
-
-    assert [column in res.columns for column in expected_columns]
-
+    assert all(column in response_dataframe.columns for column in expected_data_columns), f"Missing columns: {[col for col in expected_data_columns if col not in response_dataframe.columns]}"
 
 @pytest.mark.asyncio
-async def test_get_leaderboard_data_async():
-    res = await enact_api_helper.get_leaderboard_data_async(
-        date(2024, 8, 1),
-        date(2024, 8, 3),
-        "Plant",
-        "PoundPerMwPerH",
-        "WeightedAverageDayAheadPrice",
-        "DayAheadForward",
-        include_capacity_market_revenues=False,
-        ancillary_profit_aggregation="FrequencyAndReserve",
-        group_dx=True,
+async def test_get_index_async():
+    response_dataframe = await enact_api_helper.get_german_index_data_async(
+        date(2024,1,21),
+        date(2024,1,23),
+        '0196fb45-e59c-44a9-907a-cd76033bd504',
+        granularity="Day",
+        normalisation = "EuroPerMw"
     )
 
-    assert [column in res.columns for column in expected_columns]
-    assert [column in res.columns for column in v2_columns]
-
-
-def test_get_leaderboard_data_sync():
-    res = enact_api_helper.get_leaderboard_data(
-        date(2024, 8, 1),
-        date(2024, 8, 3),
-        "Plant",
-        "PoundPerMwPerH",
-        "WeightedAverageDayAheadPrice",
-        "DayAheadForward",
-        include_capacity_market_revenues=False,
-        ancillary_profit_aggregation="FrequencyAndReserve",
-        group_dx=True,
-    )
-
-    assert [column in res.columns for column in expected_columns]
-    assert [column in res.columns for column in v2_columns]
+    assert all(column in response_dataframe.columns for column in expected_data_columns), f"Missing columns: {[col for col in expected_data_columns if col not in response_dataframe.columns]}"

--- a/lcpdelta_python_package/tests/integration/test_api_german_index.py
+++ b/lcpdelta_python_package/tests/integration/test_api_german_index.py
@@ -1,0 +1,81 @@
+import pytest
+import time
+from datetime import date
+from tests.integration import enact_api_helper
+
+
+def teardown_function():
+    time.sleep(2)
+
+
+expected_columns = [
+    "Day",
+    "Total",
+    "Fcr",
+    "AfrrCapacity",
+    "AfrrEnergy",
+    "DayAhead",
+    "IntradayContinuous"
+]
+
+
+@pytest.mark.asyncio
+async def test_get_index():
+
+    response_dataframe = enact_api_helper.get_german_index_data(
+        date(2024,1,21),
+        date(2024,1,23),
+        'DA, IDC, aFRR Energy 1Hr 2 Cycle 50MW',
+        granularity="Day",
+        normalisation = "EuroPerMw"
+    )
+
+    assert [column in response_dataframe.columns for column in expected_columns]
+
+
+def test_get_leaderboard_data_legacy_sync():
+    res = enact_api_helper.get_leaderboard_data_legacy(
+        date(2024, 8, 1),
+        date(2024, 8, 3),
+        "Plant",
+        "PoundPerMwPerH",
+        "WeightedAverageDayAheadPrice",
+        "DayAheadForward",
+    )
+
+    assert [column in res.columns for column in expected_columns]
+
+
+@pytest.mark.asyncio
+async def test_get_leaderboard_data_async():
+    res = await enact_api_helper.get_leaderboard_data_async(
+        date(2024, 8, 1),
+        date(2024, 8, 3),
+        "Plant",
+        "PoundPerMwPerH",
+        "WeightedAverageDayAheadPrice",
+        "DayAheadForward",
+        include_capacity_market_revenues=False,
+        ancillary_profit_aggregation="FrequencyAndReserve",
+        group_dx=True,
+    )
+
+    assert [column in res.columns for column in expected_columns]
+    assert [column in res.columns for column in v2_columns]
+
+
+def test_get_leaderboard_data_sync():
+    res = enact_api_helper.get_leaderboard_data(
+        date(2024, 8, 1),
+        date(2024, 8, 3),
+        "Plant",
+        "PoundPerMwPerH",
+        "WeightedAverageDayAheadPrice",
+        "DayAheadForward",
+        include_capacity_market_revenues=False,
+        ancillary_profit_aggregation="FrequencyAndReserve",
+        group_dx=True,
+    )
+
+    assert [column in res.columns for column in expected_columns]
+    assert [column in res.columns for column in v2_columns]


### PR DESCRIPTION
Two endpoints added. One that gets the default index information e.g capacity, duration, markets to participate in, aswell as its associated GUID. The other endpoint allows to query your specified index via its GUID, with choice of dates from and to, aswell as normalisation and granularity.

![image](https://github.com/user-attachments/assets/f18048d9-d4d2-45a1-8af7-9332e3a8ebcc)

![image](https://github.com/user-attachments/assets/a5fa4542-bdce-4257-8c9b-f7fff8bafb69)


can see from running locally the data is returned

